### PR TITLE
Fixed missing IMGUI_API for IsMouseDragPastThreshold().

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1579,7 +1579,7 @@ namespace ImGui
     IMGUI_API void          SetNavIDWithRectRel(ImGuiID id, int nav_layer, const ImRect& rect_rel);
 
     // Inputs
-    inline bool             IsMouseDragPastThreshold(int button, float lock_threshold = -1.0f);
+    IMGUI_API bool          IsMouseDragPastThreshold(int button, float lock_threshold = -1.0f);
     inline bool             IsKeyPressedMap(ImGuiKey key, bool repeat = true)           { const int key_index = GImGui->IO.KeyMap[key]; return (key_index >= 0) ? IsKeyPressed(key_index, repeat) : false; }
     inline bool             IsNavInputDown(ImGuiNavInput n)                             { return GImGui->IO.NavInputs[n] > 0.0f; }
     inline bool             IsNavInputPressed(ImGuiNavInput n, ImGuiInputReadMode mode) { return GetNavInputAmount(n, mode) > 0.0f; }


### PR DESCRIPTION
(Click "Preview" to turn any http URL into a clickable link)

PLEASE CAREFULLY READ:
https://github.com/ocornut/imgui/issues/2261

(Clear this template before submitting your PR)
